### PR TITLE
Add file md5 to API

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -113,6 +113,7 @@ class Api {
 			$apiPost['ext'] = substr($file->file, $dotPos);
 			$dotPos = strrpos($file->file, '.');
 			$apiPost['tim'] = substr($file->file, 0, $dotPos);
+			$apiPost['md5'] = base64_encode(md5_file($file->file_path, true));
 		}
 
 		return $apiPost;


### PR DESCRIPTION
The API currently lacks the Base64 encoded md5 hash 4chan's API provides for posts with files attached, which assists in file de-duplication.
