### PR TITLE
Add sanity check to file md5

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -113,7 +113,9 @@ class Api {
 			$apiPost['ext'] = substr($file->file, $dotPos);
 			$dotPos = strrpos($file->file, '.');
 			$apiPost['tim'] = substr($file->file, 0, $dotPos);
-			$apiPost['md5'] = base64_encode(md5_file($file->file_path, true));
+			if(file_exists($file->file_path)) {
+				$apiPost['md5'] = base64_encode(md5_file($file->file_path, true));
+			}
 		}
 
 		return $apiPost;


### PR DESCRIPTION
Turns out md5_file explodes if the file doesn't exist. This adds a guard around the call to ensure that the file exists before trying to hash it.
