### PR TITLE
Embed field (similar to "File: ") above embedded objects

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -993,19 +993,23 @@
 	$config['embedding'] = array(
 		array(
 			'/^https?:\/\/(\w+\.)?youtube\.com\/watch\?v=([a-zA-Z0-9\-_]{10,11})(&.+)?$/i',
-			'<iframe style="float: left;margin: 10px 20px;" width="%%tb_width%%" height="%%tb_height%%" frameborder="0" id="ytplayer" src="http://www.youtube.com/embed/$2"></iframe>'
+			'<iframe style="float: left;margin: 10px 20px;" width="%%tb_width%%" height="%%tb_height%%" frameborder="0" id="ytplayer" src="http://www.youtube.com/embed/$2"></iframe>',
+			'https://youtube.com/watch?v=$2',
 		),
 		array(
 			'/^https?:\/\/(\w+\.)?vimeo\.com\/(\d{2,10})(\?.+)?$/i',
-			'<object style="float: left;margin: 10px 20px;" width="%%tb_width%%" height="%%tb_height%%"><param name="allowfullscreen" value="true" /><param name="allowscriptaccess" value="always" /><param name="movie" value="http://vimeo.com/moogaloop.swf?clip_id=$2&amp;server=vimeo.com&amp;show_title=0&amp;show_byline=0&amp;show_portrait=0&amp;color=00adef&amp;fullscreen=1&amp;autoplay=0&amp;loop=0" /><embed src="http://vimeo.com/moogaloop.swf?clip_id=$2&amp;server=vimeo.com&amp;show_title=0&amp;show_byline=0&amp;show_portrait=0&amp;color=00adef&amp;fullscreen=1&amp;autoplay=0&amp;loop=0" type="application/x-shockwave-flash" allowfullscreen="true" allowscriptaccess="always" width="%%tb_width%%" height="%%tb_height%%"></object>'
+			'<object style="float: left;margin: 10px 20px;" width="%%tb_width%%" height="%%tb_height%%"><param name="allowfullscreen" value="true" /><param name="allowscriptaccess" value="always" /><param name="movie" value="http://vimeo.com/moogaloop.swf?clip_id=$2&amp;server=vimeo.com&amp;show_title=0&amp;show_byline=0&amp;show_portrait=0&amp;color=00adef&amp;fullscreen=1&amp;autoplay=0&amp;loop=0" /><embed src="http://vimeo.com/moogaloop.swf?clip_id=$2&amp;server=vimeo.com&amp;show_title=0&amp;show_byline=0&amp;show_portrait=0&amp;color=00adef&amp;fullscreen=1&amp;autoplay=0&amp;loop=0" type="application/x-shockwave-flash" allowfullscreen="true" allowscriptaccess="always" width="%%tb_width%%" height="%%tb_height%%"></object>',
+			'http://vimeo.com/$2'
 		),
 		array(
 			'/^https?:\/\/(\w+\.)?dailymotion\.com\/video\/([a-zA-Z0-9]{2,10})(_.+)?$/i',
-			'<object style="float: left;margin: 10px 20px;" width="%%tb_width%%" height="%%tb_height%%"><param name="movie" value="http://www.dailymotion.com/swf/video/$2"><param name="allowFullScreen" value="true"><param name="allowScriptAccess" value="always"><param name="wmode" value="transparent"><embed type="application/x-shockwave-flash" src="http://www.dailymotion.com/swf/video/$2" width="%%tb_width%%" height="%%tb_height%%" wmode="transparent" allowfullscreen="true" allowscriptaccess="always"></object>'
+			'<object style="float: left;margin: 10px 20px;" width="%%tb_width%%" height="%%tb_height%%"><param name="movie" value="http://www.dailymotion.com/swf/video/$2"><param name="allowFullScreen" value="true"><param name="allowScriptAccess" value="always"><param name="wmode" value="transparent"><embed type="application/x-shockwave-flash" src="http://www.dailymotion.com/swf/video/$2" width="%%tb_width%%" height="%%tb_height%%" wmode="transparent" allowfullscreen="true" allowscriptaccess="always"></object>',
+			'https://dailymotion.com/video/$2'
 		),
 		array(
 			'/^https?:\/\/(\w+\.)?metacafe\.com\/watch\/(\d+)\/([a-zA-Z0-9_\-.]+)\/(\?.+)?$/i',
-			'<div style="float:left;margin:10px 20px;width:%%tb_width%%px;height:%%tb_height%%px"><embed flashVars="playerVars=showStats=no|autoPlay=no" src="http://www.metacafe.com/fplayer/$2/$3.swf" width="%%tb_width%%" height="%%tb_height%%" wmode="transparent" allowFullScreen="true" allowScriptAccess="always" name="Metacafe_$2" pluginspage="http://www.macromedia.com/go/getflashplayer" type="application/x-shockwave-flash"></div>'
+			'<div style="float:left;margin:10px 20px;width:%%tb_width%%px;height:%%tb_height%%px"><embed flashVars="playerVars=showStats=no|autoPlay=no" src="http://www.metacafe.com/fplayer/$2/$3.swf" width="%%tb_width%%" height="%%tb_height%%" wmode="transparent" allowFullScreen="true" allowScriptAccess="always" name="Metacafe_$2" pluginspage="http://www.macromedia.com/go/getflashplayer" type="application/x-shockwave-flash"></div>',
+			'http://metacafe.com/$2/$3'
 		),
 		array(
 			'/^https?:\/\/video\.google\.com\/videoplay\?docid=(\d+)([&#](.+)?)?$/i',
@@ -1013,7 +1017,8 @@
 		),
 		array(
 			'/^https?:\/\/(\w+\.)?vocaroo\.com\/i\/([a-zA-Z0-9]{2,15})$/i',
-			'<object style="float: left;margin: 10px 20px;" width="148" height="44"><param name="movie" value="http://vocaroo.com/player.swf?playMediaID=$2&autoplay=0"><param name="wmode" value="transparent"><embed src="http://vocaroo.com/player.swf?playMediaID=$2&autoplay=0" width="148" height="44" wmode="transparent" type="application/x-shockwave-flash"></object>'
+			'<object style="float: left;margin: 10px 20px;" width="148" height="44"><param name="movie" value="http://vocaroo.com/player.swf?playMediaID=$2&autoplay=0"><param name="wmode" value="transparent"><embed src="http://vocaroo.com/player.swf?playMediaID=$2&autoplay=0" width="148" height="44" wmode="transparent" type="application/x-shockwave-flash"></object>',
+			'https://vocaroo.com/i/$2'
 		)
 	);
 

--- a/inc/display.php
+++ b/inc/display.php
@@ -330,8 +330,10 @@ function embed_html($link) {
 			
 			$html = str_replace('%%tb_width%%', $config['embed_width'], $html);
 			$html = str_replace('%%tb_height%%', $config['embed_height'], $html);
+
+			$url = preg_replace($embed[0],$embed[2],$link);
 			
-			return $html;
+			return array($html,$url);
 		}
 	}
 	
@@ -361,8 +363,11 @@ class Post {
 		$this->mod = $mod;
 		$this->root = $root;
 		
-		if ($this->embed)
-			$this->embed = embed_html($this->embed);
+		if ($this->embed) {
+			$embed = embed_html($this->embed);
+			$this->embed = $embed[0];
+			$this->embed_url = $embed[1];
+		}
 		
 		$this->modifiers = extract_modifiers($this->body_nomarkup);
 		
@@ -416,8 +421,11 @@ class Thread {
 		$this->omitted = 0;
 		$this->omitted_images = 0;
 		
-		if ($this->embed)
-			$this->embed = embed_html($this->embed);
+		if ($this->embed) {
+			$embed = embed_html($this->embed);
+			$this->embed = $embed[0];
+			$this->embed_url = $embed[1];
+		}
 		
 		$this->modifiers = extract_modifiers($this->body_nomarkup);
 		

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -884,7 +884,7 @@ function insertFloodPost(array $post) {
 
 function post(array $post) {
 	global $pdo, $board;
-	$query = prepare(sprintf("INSERT INTO ``posts_%s`` VALUES ( NULL, :thread, :subject, :email, :name, :trip, :capcode, :body, :body_nomarkup, :time, :time, :files, :num_files, :filehash, :password, :ip, :sticky, :locked, 0, :embed)", $board['uri']));
+	$query = prepare(sprintf("INSERT INTO ``posts_%s`` VALUES ( NULL, :thread, :subject, :email, :name, :trip, :capcode, :body, :body_nomarkup, :time, :time, :files, :num_files, :filehash, :password, :ip, :sticky, :locked, 0, :embed, :embed_url)", $board['uri']));
 
 	// Basic stuff
 	if (!empty($post['subject'])) {
@@ -932,8 +932,10 @@ function post(array $post) {
 
 	if (!empty($post['embed'])) {
 		$query->bindValue(':embed', $post['embed']);
+		$query->bindValue(':embed_url', $post['embed_url']);
 	} else {
 		$query->bindValue(':embed', null, PDO::PARAM_NULL);
+		$query->bindValue(':embed_url', null, PDO::PARAM_NULL);
 	}
 
 	if ($post['op']) {

--- a/install.php
+++ b/install.php
@@ -1,7 +1,7 @@
 <?php
 
 // Installation/upgrade file	
-define('VERSION', '4.9.92');
+define('VERSION', '4.9.93');
 
 require 'inc/functions.php';
 
@@ -547,6 +547,10 @@ if (file_exists($config['has_installed'])) {
 			}
 		case '4.9.90':
 		case '4.9.91':
+		case '4.9.92':
+				foreach($boards as &$board) {
+					query(sprintf('ALTER TABLE ``posts_%s`` ADD `embed_url` text DEFAULT NULL',$board['uri'])) or error(db_error());
+				}
 		case false:
 			// TODO: enhance Tinyboard -> vichan upgrade path.
 			query("CREATE TABLE IF NOT EXISTS ``search_queries`` (  `ip` varchar(39) NOT NULL,  `time` int(11) NOT NULL,  `query` text NOT NULL) ENGINE=MyISAM DEFAULT CHARSET=utf8;") or error(db_error());

--- a/js/youtube.js
+++ b/js/youtube.js
@@ -16,7 +16,8 @@
 *	$config['embedding'] = array();
 *	$config['embedding'][0] = array(
 *		'/^https?:\/\/(\w+\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9\-_]{10,11})(&.+)?$/i',
-*		$config['youtube_js_html']);
+*		$config['youtube_js_html'],
+*		'https://youtube.com/watch?v=$2');
 *   $config['additional_javascript'][] = 'js/jquery.min.js';
 *   $config['additional_javascript'][] = 'js/youtube.js';
 *

--- a/post.php
+++ b/post.php
@@ -270,6 +270,8 @@ if (isset($_POST['delete'])) {
 			if (preg_match($embed[0], $value)) {
 				// Valid link
 				$post['embed'] = $value;
+				// Won't get filtered by embed_html
+				$post['embed_url'] = $value;
 				// This is bad, lol.
 				$post['no_longer_require_an_image_for_op'] = true;
 				break;

--- a/templates/post/fileinfo.html
+++ b/templates/post/fileinfo.html
@@ -1,5 +1,10 @@
 	{% if post.embed %}
-		{{ post.embed }}
+		<div class="files">
+			<p class="fileinfo">Embed: <span class="unimportant"><a href="{{ post.embed_url }}">{{ post.embed_url }}</a></span></p>
+			<div class="file">
+			{{ post.embed }}
+			</div>
+		</div>
     {% else %}
     <div class="files">
     {% for file in post.files %}

--- a/templates/posts.sql
+++ b/templates/posts.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS ``posts_{{ board }}`` (
    `locked` int(1) NOT NULL,
    `sage` int(1) NOT NULL,
    `embed` text,
+   `embed_url` text,
    UNIQUE KEY `id` (`id`),
    KEY `thread_id` (`thread`,`id`),
    KEY `filehash` (`filehash`(40)),


### PR DESCRIPTION
This pull request adds an "Embed: " field in the same fashion as images use the "File: " field. The importance of this is that users that do not load remote content (noscript, request policy, text browsers, etc.) cannot see the remote content.

The commit is pretty self-explanatory but you can see this feature in action here:
http://a.pomf.se/gkluex.png