### PR TITLE
Scroll hook thread polling adjusttment.

### DIFF
--- a/js/auto-reload.js
+++ b/js/auto-reload.js
@@ -211,7 +211,7 @@ $(document).ready(function(){
 			}
 			end_of_page = true;
 		}
-	}).trigger('scroll');
+	});
 
 	$('#update_thread').on('click', function() { poll(manualUpdate = true); return false; });
 


### PR DESCRIPTION
Fixed an issue with the scroll hook thread polling.
Users scrolling near the bottom of the page are making upwards of 7-10 requests a second to the site.

Added a small timer using the "poll_interval_mindelay" value to prevent unnecessary polling, one is enough during this minimum time delay.
