### PR TITLE
Add secrets.example.php, make dnsbls.php optional

### DIFF
--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -10,6 +10,8 @@
 	require_once "lib/htmlpurifier-4.5.0/library/HTMLPurifier.auto.php";
 	require_once "8chan-functions.php";
 
+	// Note - you may want to change some of these in secrets.php instead of here
+	// See the secrets.example.php file
 	$config['db']['server'] = 'localhost';
 	$config['db']['database'] = '8chan';
 	$config['db']['prefix'] = '';

--- a/inc/secrets.example.php
+++ b/inc/secrets.example.php
@@ -1,0 +1,19 @@
+<?php
+/*
+ * Secrets for configuration
+ *
+ * Included from instance-config.php.
+ *
+ * Copy this file to secrets.php and edit.
+ */
+
+$config['db']['server'] = 'localhost';
+$config['db']['database'] = '8chan';
+//$config['db']['prefix'] = '';
+$config['db']['user'] = 'eightchan-user';
+$config['db']['password'] = 'mysecretpassword';
+
+// Consider generating these from the following command.
+// $ cat /proc/sys/kernel/random/uuid
+$config['secure_trip_salt'] = 'generate-a-uuid';
+$config['cookies']['salt'] = 'generate-a-uuid';


### PR DESCRIPTION
This is an alternate solution to pull #134.

A file, secrets.example.php, is added to serve as an example for the secrets.php file, which is now required.
The DNSBL file is made optional.

The database configuration, the tripcode salt, and the cookie salt are in the example secrets.php file.

Advice to generate the salts from the kernel's random number generator is included, as that will give ~120 bits of entropy.
