### PR TITLE
Fix overly wide posts

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -289,7 +289,6 @@ div.post.reply {
 }
 
 div.post_modified {
-  min-width: 47.5em;
   margin-left: 1.8em;
 }
 


### PR DESCRIPTION
Removed a CSS property that was making some posts too wide and breaking post previews.
