### PR TITLE
Offset post anchors to compensate for boardlist

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -1015,3 +1015,22 @@ span.pln {
 div.mix {
 	display: inline-block;
 }
+
+a.post_anchor {
+  display: inline-block;
+  visibility: hidden;
+}
+
+.intro > a.post_anchor {
+  position: relative;
+  top: -38px;
+}
+
+.thread > a.post_anchor {
+  position: absolute;
+  top: -20px;
+}
+
+.thread {
+  position: relative;
+}


### PR DESCRIPTION
After clicking a quotelink in a thread, the boardlist at the top hides some part of the linked post. This PR is a CSS hack to compensate for the boardlist. NOT tested on mobile.
