### PR TITLE
Added mod function to spoiler all images in a given post

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -1235,6 +1235,7 @@
 	$config['mod']['link_bandelete'] = '[B&amp;D]';
 	$config['mod']['link_deletefile'] = '[F]';
 	$config['mod']['link_spoilerimage'] = '[S]';
+	$config['mod']['link_spoilerimages'] = '[S+]';
 	$config['mod']['link_deletebyip'] = '[D+]';
 	$config['mod']['link_deletebyip_global'] = '[D++]';
 	$config['mod']['link_sticky'] = '[Sticky]';

--- a/inc/mod/pages.php
+++ b/inc/mod/pages.php
@@ -1758,6 +1758,51 @@ function mod_spoiler_image($board, $post, $file) {
 	header('Location: ?/' . sprintf($config['board_path'], $board) . $config['file_index'], true, $config['redirect_http']);
 }
 
+function mod_spoiler_images($board, $post) {
+	global $config, $mod;
+	   
+	if (!openBoard($board))
+		error($config['error']['noboard']);
+	   
+	if (!hasPermission($config['mod']['spoilerimage'], $board))
+		error($config['error']['noaccess']);
+
+	// Delete file thumbnails
+	$query = prepare(sprintf("SELECT `files`, `thread` FROM ``posts_%s`` WHERE id = :id", $board));
+	$query->bindValue(':id', $post, PDO::PARAM_INT);
+	$query->execute() or error(db_error($query));
+	$result = $query->fetch(PDO::FETCH_ASSOC);
+	$files = json_decode($result['files']);
+	
+	foreach ($files as $file => $name) {
+		$size_spoiler_image = @getimagesize($config['spoiler_image']);
+		file_unlink($config['dir']['img_root'] . $board . '/' . $config['dir']['thumb'] . $files[$file]->thumb);
+		$files[$file]->thumb = 'spoiler';
+		$files[$file]->thumbwidth = $size_spoiler_image[0];
+		$files[$file]->thumbheight = $size_spoiler_image[1];
+	};
+	// Make thumbnail spoiler
+	$query = prepare(sprintf("UPDATE ``posts_%s`` SET `files` = :files WHERE `id` = :id", $board));
+	$query->bindValue(':files', json_encode($files));
+	$query->bindValue(':id', $post, PDO::PARAM_INT);
+	$query->execute() or error(db_error($query));
+
+	// Record the action
+	modLog("Spoilered file from post #{$post}");
+
+	// Rebuild thread
+	buildThread($result['thread'] ? $result['thread'] : $post);
+
+	// Rebuild board
+	buildIndex();
+
+	// Rebuild themes
+	rebuildThemes('post-delete', $board);
+	   
+	// Redirect
+	header('Location: ?/' . sprintf($config['board_path'], $board) . $config['file_index'], true, $config['redirect_http']);
+}
+
 function mod_deletebyip($boardName, $post, $global = false) {
 	global $config, $mod, $board;
 	

--- a/mod.php
+++ b/mod.php
@@ -95,6 +95,7 @@ $pages = array(
 	'/(\%b)/delete/(\d+)'                             => 'secure delete',          // delete post
 	'/(\%b)/deletefile/(\d+)/(\d+)'                   => 'secure deletefile',      // delete file from post
 	'/(\%b+)/spoiler/(\d+)/(\d+)'                     => 'secure spoiler_image',   // spoiler file
+	'/(\%b+)/spoiler_all/(\d+)'                       => 'secure spoiler_images',   // spoiler file
 	'/(\%b)/deletebyip/(\d+)(/global)?'               => 'secure deletebyip',      // delete all posts by IP address
 	'/(\%b)/(un)?lock/(\d+)'                          => 'secure lock',            // lock thread
 	'/(\%b)/(un)?sticky/(\d+)'                        => 'secure sticky',          // sticky thread

--- a/templates/post/post_controls.html
+++ b/templates/post/post_controls.html
@@ -1,6 +1,9 @@
 {% if mod %}
 
 <span class="controls {% if not post.thread %}op{% endif %}">
+{% if mod|hasPermission(config.mod.spoilerimage, board.uri) %}
+	{{ secure_link_confirm(config.mod.link_spoilerimages, 'Spoiler All'|trans, 'Are you sure you want to spoiler all images on this post?'|trans, board.dir ~ 'spoiler_all/' ~ post.id) }}&nbsp;
+{% endif %}
 {% if mod|hasPermission(config.mod.delete, board.uri) %}
 	{{ secure_link_confirm(config.mod.link_delete, 'Delete'|trans, 'Are you sure you want to delete this?'|trans, board.dir ~ 'delete/' ~ post.id) }}&nbsp;
 {% endif %}


### PR DESCRIPTION
It's quite tedious to manually spoiler multiple images in a post when the redirect takes the mod away from the post/page they are trying to spoil images on. This will help make things a bit quicker when modding nsfw stuff.