### PR TITLE
Added references to unused javascript files

### DIFF
--- a/inc/instance-config.php
+++ b/inc/instance-config.php
@@ -142,6 +142,11 @@
 	$config['additional_javascript'][] = 'js/quote-selection.js';
 	$config['additional_javascript'][] = 'js/twemoji/twemoji.js';
 	$config['additional_javascript'][] = 'js/flag-previews.js';
+	$config['additional_javascript'][] = 'js/disable-styles.js';
+	$config['additional_javascript'][] = 'js/jszip.min.js';
+	$config['additional_javascript'][] = 'js/download-all.js';
+	$config['additional_javascript'][] = 'js/save-user_flag.js';
+
 
 	//$config['font_awesome_css'] = '/netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css';
 	


### PR DESCRIPTION
I, and probably some other people, assumed that the files in the js folder were combined automatically and neglected to reference them anywhere; this appears to be the correct place to put the references, and looking through them and the js folder, some of the javascript files aren’t referenced but their functionality is still present on the live site (thread watching and board favoriteing without watch.js), and I didn’t add those as I don’t want to break the site.