### PR TITLE
Updated dnsbl to only block exit nodes

### DIFF
--- a/inc/config.php
+++ b/inc/config.php
@@ -184,7 +184,7 @@
 
 	// Prevents most Tor exit nodes from making posts. Recommended, as a lot of abuse comes from Tor because
 	// of the strong anonymity associated with it.
-	$config['dnsbl'][] = array('tor.dnsbl.sectoor.de', 1);
+	$config['dnsbl'][] = array('exitnodes.tor.dnsbl.sectoor.de', 1);
 
 	// http://www.sorbs.net/using.shtml
 	// $config['dnsbl'][] = array('dnsbl.sorbs.net', array(2, 3, 4, 5, 6, 7, 8, 9));


### PR DESCRIPTION
This is re: https://8chan.co/meta/res/42025.html

It's unnecessary to block Tor relays, as they only route traffic within the Tor network. Its a minor inconvenience for relay operators, as we have to bypass the DNSBL daily even though we don't use Tor clients. Instead, I suggest you only block exit nodes, as in this pull request.

Note - I haven't tested this at all, I'm just going off http://www.sectoor.de/tor.php