### PR TITLE
fix Relative Time and Image Throttler

### DIFF
--- a/js/inline-expanding.js
+++ b/js/inline-expanding.js
@@ -12,7 +12,7 @@
  *
  */
 
-onready(function(){
+$(document).ready(function(){
 	'use strict';
 
 	var DEFAULT_MAX = 5;  // default maximum image loads

--- a/js/local-time.js
+++ b/js/local-time.js
@@ -13,7 +13,7 @@
  *
  */
 
-onready(function(){
+$(document).ready(function(){
 	'use strict';
 
 	var iso8601 = function(s) {


### PR DESCRIPTION
Following the example of other features that are user configurable, changed the code to use `$(document).ready`, because I got a sinking feeling `onready` is causing them to be run far earlier than they rightly should:
![my bad](https://cloud.githubusercontent.com/assets/7380439/5859192/69e6b5ba-a293-11e4-866d-c3c4f052b5e4.PNG)