### PR TITLE
Bug fix: external post preview

### DIFF
--- a/js/post-hover.js
+++ b/js/post-hover.js
@@ -217,6 +217,12 @@ onready(function(){
 							} else {
 								thumb_url = (this.isSpoiler) ? '/static/spoiler.png' : '/static/file.png';
 							}
+
+                            // truncate long filenames
+                            if (this.filename.length > 23) {
+                                this.filename = this.filename.substr(0, 22) + '…';
+                            }
+
 							// file infos
 							var $ele = $('<div class="file">')
 										.append($('<p class="fileinfo">')
@@ -224,7 +230,7 @@ onready(function(){
 											.append('<a>'+ this.filename + file_ext +'</a>')
 											.append('<span class="unimportant"> ('+ bytesToSize(this.fsize) +', '+ this.w +'x'+ this.h +')</span>')
 										);
-							if (multifile) $ele.addClass('multifile').css('max-width', '200px');
+							if (multifile) $ele.addClass('multifile').css('width', this.thumb_w + 30);
 
 							// image
 							var $img = $('<img class="post-image">')

--- a/js/post-hover.js
+++ b/js/post-hover.js
@@ -212,7 +212,7 @@ onready(function(){
 
 							if (this.isImage && !this.isSpoiler) {
 								// video files uses jpg for thumbnail
-								if (this.ext === '.webm' || this.ext === '.mp4') this.ext = '.jpg';
+								if (this.ext === '.webm' || this.ext === '.mp4' || this.ext === '.jpeg') this.ext = '.jpg';
 								thumb_url = '/'+ board +'/thumb/' + this.tim + this.ext;
 							} else {
 								thumb_url = (this.isSpoiler) ? '/static/spoiler.png' : '/static/file.png';


### PR DESCRIPTION
- Fix the occasional thumbnail and filename overlap by truncating longer
filenames and set file container width according to thumbnail width.
- Fix thumbnail images sometimes using `.jpeg` file extension, resulting in 404.

Screencap of issue: 
![bug](https://cloud.githubusercontent.com/assets/7380439/5940447/d8018ffa-a745-11e4-8ee0-4f944e0be9d5.png)
