### PR TITLE
Option to enable captcha for thread creation only + README.md with better install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,28 @@
-infinity
-========================================================
 
-About
-------------
-infinity is a fork of vichan, with the difference that infinity is geared towards allowing users to create their own boards. A running instance is at [8ch.net](https://8ch.net/)
+This fork adds a new board option to infinity:
 
-Most things (other than installation) that apply to upstream vichan also apply to infinity. See their readme for a detailed FAQ: https://github.com/vichan-devel/vichan/blob/master/README.md
+The requirement to solve a captcha in order to create a thread, but not in order to post a reply.
 
-If you are not interested in letting your users make their own boards, install vichan instead of infinity.
+Here's a quick rundown of where code edits have been made:
 
-Because I cannot be bothered to maintain `install.php`, the install process is as such:
+ALL CODE EDITS FOR NEW THREAD CAPTCHA ARE MARKED WITH THE COMMENT "New thread captcha"
+ONE ADITIONAL EDIT TO SETTINGS.HTML MARKED WITH:
+<!--Added explanation to clarify purpose of "Enable CAPTCHA" now that "Enable CAPTCHA for new thread creation only" also exists-->
+The $config setting for new thread captcha is $config[new_thread_capt]
 
-```
-mysql -uroot infinity < install.sql
-echo 'infinity' > .installed
-```
+templates/mod/settings.html
+Option for new captcha thread creation has been added to the settings template.
+"Enable CAPTCHA" also clarified with better description.
 
-Here's my install script as of 11/14/2014 for the 8chan servers which run Ubuntu 14.04:
+inc/8chan-mod-pages.php
+Two lines of code added to 8chan-mod-pages.php
 
-```
-apt-get install graphicsmagick gifsicle php5-fpm mysql-client php5-mysql php5-cli php-pear php5-apcu; add-apt-repository ppa:jon-severinsson/ffmpeg; add-apt-repository ppa:nginx/stable; apt-get update; apt-get install nginx ffmpeg; pear install Net_DNS2
-```
+inc/config.php
+Line added, makes new thread captcha default to off.
 
-Have fun!
+/templates/post_form.html
+Several lines added. Makes the verification box show up in the new thread form
+when $config[new_thread_capt] is enabled. 
+
+/post.php
+Added two new conditions to if statement.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ Step 4. Infinity can function in a very barebones fashion after the first two st
 apt-get install graphicsmagick gifsicle php5-fpm mysql-client php5-mysql php5-cli php-pear php5-apcu; add-apt-repository ppa:jon-severinsson/ffmpeg; add-apt-repository ppa:nginx/stable; apt-get update; apt-get install nginx ffmpeg; pear install Net_DNS2
 ```
 
-Step 5. The current captcha provider listed inc/config.php is dead. You may want to work around this.  
+Step 5. The current captcha provider listed inc/config.php is dead. You may want to work around this. 
 
 Have fun!

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Here's a quick rundown of where code edits have been made:
 
 ALL CODE EDITS FOR NEW THREAD CAPTCHA ARE MARKED WITH THE COMMENT "New thread captcha"
 ONE ADITIONAL EDIT TO SETTINGS.HTML MARKED WITH:
-"Added explanation to clarify purpose of "Enable CAPTCHA" now that "Enable CAPTCHA for new thread creation only" also exists"
+"Added explanation to clarify purpose of "Enable CAPTCHA" now that "Enable CAPTCHA for new thread creation only" also exists".
+
 The $config setting for new thread captcha is $config[new_thread_capt]
 
 templates/mod/settings.html

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you are not interested in letting your users make their own boards, install v
 Installation
 ------------
 Basic requirements:
-A computer running a Unix-like OS(infinity has been specifically tested with and is known to work under Ubuntu 14.x), Apache, MySQL, and PHP
+A computer running a Unix or Unix-like OS(infinity has been specifically tested with and is known to work under Ubuntu 14.x), Apache, MySQL, and PHP
 * Make sure Apache has read/write access to the directory infinity resides in.
 * `install.php` is not maintained. Don't use it.
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,59 @@
+infinity
+========================================================
 
-This fork adds a new board option to the version of infinity as of Jan. 28th 2015:
+About
+------------
+infinity is a fork of vichan, with the difference that infinity is geared towards allowing users to create their own boards. A running instance is at [8ch.net](https://8ch.net/)
 
-The requirement to solve a captcha in order to create a thread, but not in order to post a reply.
+Most things (other than installation) that apply to upstream vichan also apply to infinity. See their readme for a detailed FAQ: https://github.com/vichan-devel/vichan/blob/master/README.md
 
-Here's a quick rundown of where code edits have been made:
+If you are not interested in letting your users make their own boards, install vichan instead of infinity.
 
-ALL CODE EDITS FOR NEW THREAD CAPTCHA ARE MARKED WITH THE COMMENT "New thread captcha"
-ONE ADITIONAL EDIT TO SETTINGS.HTML MARKED WITH:
-"Added explanation to clarify purpose of "Enable CAPTCHA" now that "Enable CAPTCHA for new thread creation only" also exists".
+Installation
+------------
+Basic requirements:
+A server running a Unix-like OS(infinity has been specifically tested with and is known to work under Ubuntu 14.x)
+Apache, MySQL, and PHP
+* Make sure Apache has read/write access to the directory infinity resides in.
+* `install.php` is not maintained. Don't use it.
 
-The $config setting for new thread captcha is $config[new_thread_capt]
+Step 1. Create infinity's database from the included install.sql file. Enter mysql and create an empty database named 'infinity'. Then, cd into the infinity base directory and run:
+```
+mysql -uroot -p infinity < install.sql
+echo 'infinity' > .installed
+```
 
-templates/mod/settings.html
-Option for new captcha thread creation has been added to the settings template.
-"Enable CAPTCHA" also clarified with better description.
+Step 2. /inc/secrets.php does not exist by default, but infinity needs it in order to function. To remedy this, cd into /inc/ and run:
+```
+sudo cp secrets.example.php secrets.php
+```
 
-inc/8chan-mod-pages.php
-Three lines of code added to 8chan-mod-pages.php
+Now open secrets.php and edit the $config['db'] settings to point to the 'infinity' MySQL database you created in Step 1. 'user' and 'password' refer to your MySQL login credentials.  It should look something like this when you're finished:
 
-inc/config.php
-Line added, makes new thread captcha default to off.
+```
+	$config['db']['server'] = 'localhost';
+	$config['db']['database'] = 'infinity';
+	$config['db']['prefix'] = '';
+	$config['db']['user'] = 'root';
+	$config['db']['password'] = 'password';
+	$config['timezone'] = 'UTC';
+	$config['cache']['enabled'] = 'apc';
+```
 
-/templates/post_form.html
-Several lines added. Makes the verification box show up in the new thread form
-when $config[new_thread_capt] is enabled. 
+Step 3.(Optional) By default, infinity will ignore any changes you make to the template files until you log into mod.php, go to Rebuild, and select Flush Cache. You may find this inconvenient. To make infinity automatically accept your changes to template files, open /inc/template.php and add:
 
-/post.php
-Added two new conditions to if statement.
+```
+'auto_reload' => true
+```
+
+To the array of settings passed to Twig_Environment().
+
+Step 4. Infinity can function in a very barebones fashion after the first two steps, but you should probably install these additional packages if you want to seriously run it and/or contribute to it. ffmpeg may fail to intall under certain versions of Ubuntu. If it does, remove it from the script below and install it via an alternate method. Make sure to run the below as root:
+
+```
+apt-get install graphicsmagick gifsicle php5-fpm mysql-client php5-mysql php5-cli php-pear php5-apcu; add-apt-repository ppa:jon-severinsson/ffmpeg; add-apt-repository ppa:nginx/stable; apt-get update; apt-get install nginx ffmpeg; pear install Net_DNS2
+```
+
+Step 5. The current captcha provider listed inc/config.php is dead. You may want to work around this.  
+
+Have fun!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-This fork adds a new board option to infinity:
+This fork adds a new board option to the version of infinity as of Jan. 28th 2015:
 
 The requirement to solve a captcha in order to create a thread, but not in order to post a reply.
 
@@ -15,7 +15,7 @@ Option for new captcha thread creation has been added to the settings template.
 "Enable CAPTCHA" also clarified with better description.
 
 inc/8chan-mod-pages.php
-Two lines of code added to 8chan-mod-pages.php
+Three lines of code added to 8chan-mod-pages.php
 
 inc/config.php
 Line added, makes new thread captcha default to off.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ If you are not interested in letting your users make their own boards, install v
 Installation
 ------------
 Basic requirements:
-A server running a Unix-like OS(infinity has been specifically tested with and is known to work under Ubuntu 14.x)
-, Apache, MySQL, and PHP
+A server running a Unix-like OS(infinity has been specifically tested with and is known to work under Ubuntu 14.x), Apache, MySQL, and PHP
 * Make sure Apache has read/write access to the directory infinity resides in.
 * `install.php` is not maintained. Don't use it.
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ A computer running a Unix or Unix-like OS(infinity has been specifically tested 
 * Make sure Apache has read/write access to the directory infinity resides in.
 * `install.php` is not maintained. Don't use it.
 
-Step 1. Create infinity's database from the included install.sql file. Enter mysql and create an empty database named 'infinity'. Then, cd into the infinity base directory and run:
+Step 1. Create infinity's database from the included install.sql file. Enter mysql and create an empty database named 'infinity'. Then cd into the infinity base directory and run:
 ```
 mysql -uroot -p infinity < install.sql
 echo 'infinity' > .installed
 ```
 
-Step 2. /inc/secrets.php does not exist by default, but infinity needs it in order to function. To remedy this, cd into /inc/ and run:
+Step 2. /inc/secrets.php does not exist by default, but infinity needs it in order to function. To fix this, cd into /inc/ and run:
 ```
 sudo cp secrets.example.php secrets.php
 ```
@@ -39,7 +39,7 @@ Now open secrets.php and edit the $config['db'] settings to point to the 'infini
 	$config['cache']['enabled'] = 'apc';
 ```
 
-Step 3.(Optional) By default, infinity will ignore any changes you make to the template files until you log into mod.php, go to Rebuild, and select Flush Cache. You may find this inconvenient. To make infinity automatically accept your changes to template files, open /inc/template.php and add:
+Step 3.(Optional) By default, infinity will ignore any changes you make to the template files until you log into mod.php, go to Rebuild, and select Flush Cache. You may find this inconvenient. To make infinity automatically accept your changes to the template files, open /inc/template.php and add:
 
 ```
 'auto_reload' => true
@@ -47,7 +47,7 @@ Step 3.(Optional) By default, infinity will ignore any changes you make to the t
 
 To the array of settings passed to Twig_Environment().
 
-Step 4. Infinity can function in a very barebones fashion after the first two steps, but you should probably install these additional packages if you want to seriously run it and/or contribute to it. ffmpeg may fail to install under certain versions of Ubuntu. If it does, remove it from the script below and install it via an alternate method. Make sure to run the below as root:
+Step 4. Infinity can function in a very barebones fashion after the first two steps, but you should probably install these additional packages if you want to seriously run it and/or contribute to it. ffmpeg may fail to install under certain versions of Ubuntu. If it does, remove it from this script and install it via an alternate method. Make sure to run the below as root:
 
 ```
 apt-get install graphicsmagick gifsicle php5-fpm mysql-client php5-mysql php5-cli php-pear php5-apcu; add-apt-repository ppa:jon-severinsson/ffmpeg; add-apt-repository ppa:nginx/stable; apt-get update; apt-get install nginx ffmpeg; pear install Net_DNS2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Here's a quick rundown of where code edits have been made:
 
 ALL CODE EDITS FOR NEW THREAD CAPTCHA ARE MARKED WITH THE COMMENT "New thread captcha"
 ONE ADITIONAL EDIT TO SETTINGS.HTML MARKED WITH:
-<!--Added explanation to clarify purpose of "Enable CAPTCHA" now that "Enable CAPTCHA for new thread creation only" also exists-->
+"Added explanation to clarify purpose of "Enable CAPTCHA" now that "Enable CAPTCHA for new thread creation only" also exists"
 The $config setting for new thread captcha is $config[new_thread_capt]
 
 templates/mod/settings.html

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Step 3.(Optional) By default, infinity will ignore any changes you make to the t
 
 To the array of settings passed to Twig_Environment().
 
-Step 4. Infinity can function in a very barebones fashion after the first two steps, but you should probably install these additional packages if you want to seriously run it and/or contribute to it. ffmpeg may fail to intall under certain versions of Ubuntu. If it does, remove it from the script below and install it via an alternate method. Make sure to run the below as root:
+Step 4. Infinity can function in a very barebones fashion after the first two steps, but you should probably install these additional packages if you want to seriously run it and/or contribute to it. ffmpeg may fail to install under certain versions of Ubuntu. If it does, remove it from the script below and install it via an alternate method. Make sure to run the below as root:
 
 ```
 apt-get install graphicsmagick gifsicle php5-fpm mysql-client php5-mysql php5-cli php-pear php5-apcu; add-apt-repository ppa:jon-severinsson/ffmpeg; add-apt-repository ppa:nginx/stable; apt-get update; apt-get install nginx ffmpeg; pear install Net_DNS2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation
 ------------
 Basic requirements:
 A server running a Unix-like OS(infinity has been specifically tested with and is known to work under Ubuntu 14.x)
-Apache, MySQL, and PHP
+, Apache, MySQL, and PHP
 * Make sure Apache has read/write access to the directory infinity resides in.
 * `install.php` is not maintained. Don't use it.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you are not interested in letting your users make their own boards, install v
 Installation
 ------------
 Basic requirements:
-A server running a Unix-like OS(infinity has been specifically tested with and is known to work under Ubuntu 14.x), Apache, MySQL, and PHP
+A computer running a Unix-like OS(infinity has been specifically tested with and is known to work under Ubuntu 14.x), Apache, MySQL, and PHP
 * Make sure Apache has read/write access to the directory infinity resides in.
 * `install.php` is not maintained. Don't use it.
 

--- a/inc/8chan-mod-pages.php
+++ b/inc/8chan-mod-pages.php
@@ -598,7 +598,7 @@ EOT;
 		$query->bindValue(':board', $b);
 		$query->execute() or error(db_error($query));
 		$board = $query->fetchAll()[0];
-
+ 
 		$rules = @file_get_contents($board['uri'] . '/rules.txt');
 		$css = @file_get_contents('stylesheets/board/' . $board['uri'] . '.css');
 	

--- a/inc/8chan-mod-pages.php
+++ b/inc/8chan-mod-pages.php
@@ -577,7 +577,7 @@ EOT;
 
 			// be smarter about rebuilds...only some changes really require us to rebuild all threads
 			if ($_config['captcha']['enabled'] != $config['captcha']['enabled']
-			 || $_config['new_thread_capt'] != $config['new_tread_capt'] /*New thread captcha - if toggling "enable captcha" requires this, toggling new thread capt does too, I guess.*/
+			 || $_config['new_thread_capt'] != $config['new_thread_capt'] /*New thread captcha - if toggling "enable captcha" requires this, toggling new thread capt does too, I guess.*/
 			 || $_config['captcha']['extra'] != $config['captcha']['extra']
 			 || $_config['blotter'] != $config['blotter']
 			 || $_config['field_disable_name'] != $config['field_disable_name']

--- a/inc/8chan-mod-pages.php
+++ b/inc/8chan-mod-pages.php
@@ -408,6 +408,8 @@ FLAGS;
 			$user_flags = isset($_POST['user_flags']) ? "if (file_exists('$b/flags.php')) { include 'flags.php'; }\n" : '';
 			$captcha = isset($_POST['captcha']) ? 'true' : 'false';
 			$force_subject_op = isset($_POST['force_subject_op']) ? 'true' : 'false';
+			/*New thread captcha*/
+			$new_thread_capt = isset($_POST['new_thread_capt']) ? 'true' : 'false';
 			
 
 
@@ -502,6 +504,8 @@ OEKAKI;
 \$config['default_stylesheet'] = array('Custom', \$config['stylesheets']['Custom']);
 \$config['captcha']['enabled'] = $captcha;
 \$config['force_subject_op'] = $force_subject_op;
+/*New thread captcha*/
+\$config['new_thread_capt'] = $new_thread_capt;
 \$config['hour_max_threads'] = $hour_max_threads;
 $code_tags $katex $oekaki $replace $multiimage $allow_flash $allow_pdf $user_flags
 if (\$config['disable_images'])

--- a/inc/8chan-mod-pages.php
+++ b/inc/8chan-mod-pages.php
@@ -577,6 +577,7 @@ EOT;
 
 			// be smarter about rebuilds...only some changes really require us to rebuild all threads
 			if ($_config['captcha']['enabled'] != $config['captcha']['enabled']
+			 || $_config['new_thread_capt'] != $config['new_tread_capt'] /*New thread captcha - if toggling "enable captcha" requires this, toggling new thread capt does too, I guess.*/
 			 || $_config['captcha']['extra'] != $config['captcha']['extra']
 			 || $_config['blotter'] != $config['blotter']
 			 || $_config['field_disable_name'] != $config['field_disable_name']

--- a/inc/config.php
+++ b/inc/config.php
@@ -445,6 +445,11 @@
  * ====================
  */
 
+	//New thread captcha
+	//Require solving a captcha to post a thread. 
+	//Default off.
+	$config['new_thread_capt'] = false;
+	
 	// Do you need a body for your reply posts?
 	$config['force_body'] = false;
 	// Do you need a body for new threads?

--- a/post.php
+++ b/post.php
@@ -236,7 +236,9 @@ elseif (isset($_POST['post'])) {
 	}
 
 	// Same, but now with our custom captcha provider
-	if ($config['captcha']['enabled']) {
+	//if ($config['captcha']['enabled']) {
+	//New thread captcha
+	if (($config['captcha']['enabled']) || (($post['op']) && ($config['new_thread_capt'])) ) {
 		$resp = file_get_contents($config['captcha']['provider_check'] . "?" . http_build_query([
 			'mode' => 'check',
 			'text' => $_POST['captcha_text'],

--- a/templates/mod/settings.html
+++ b/templates/mod/settings.html
@@ -45,7 +45,10 @@
 		<tr><th>{% trans %}Enable dice rolling{% endtrans %}</th><td><input type="checkbox" name="allow_roll" {% if config.allow_roll %}checked{% endif %}></td></tr>
 		<tr><th>{% trans %}Don't allow users to repost images{% endtrans %}</th><td><input type="checkbox" name="image_reject_repost" {% if config.image_reject_repost %}checked{% endif %}></td></tr>
 		<tr><th>{% trans %}Allow a poster to delete his own posts{% endtrans %}</th><td><input type="checkbox" name="allow_delete" {% if config.allow_delete %}checked{% endif %}></td></tr>
-		<tr><th>{% trans %}Enable CAPTCHA{% endtrans %}<br/><span class="unimportant">This is not ReCAPTCHA, it is custom to 8chan</span></th><td><input type="checkbox" name="captcha" {% if config.captcha.enabled %}checked{% endif %}></td></tr>
+		<!--Added explanation to clarify purpose of "Enable CAPTCHA" now that "Enable CAPTCHA for new thread creation only" also exists-->
+		<tr><th>{% trans %}Enable CAPTCHA{% endtrans %}<br/><span class="unimportant">Users must solve a CAPTCHA in order to post.<br> This is not ReCAPTCHA, it is custom to 8chan.</span></th><td><input type="checkbox" name="captcha" {% if config.captcha.enabled %}checked{% endif %}></td></tr>
+		<!--New thread captcha start-->
+		<tr><th>{% trans %}Enable CAPTCHA for thread creation only{% endtrans %}<br/><span class="unimportant">Users must solve a CAPTCHA in order to create new threads,<br>but do not have to solve a CAPTCHA in order to post replies.</span></th><td><input type="checkbox" name="new_thread_capt" {% if config.new_thread_capt %}checked{% endif %}></td></tr>
 		<tr><th>{% trans %}Language{% endtrans %}<br/><span class="unimportant">{% trans %}To contribute translations, register at <a href="https://www.transifex.com/projects/p/tinyboard-vichan-devel/">Transifex</a>{% endtrans %}</span></th><td>
 		<select name="locale">
 			<option value="en" {% if "en" == config.locale %}selected{% endif %}>en</option>

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -89,6 +89,20 @@
 				<script>load_captcha("{{ config.captcha.provider_get }}", "{{ config.captcha.extra }}");</script>
 			</td>
 		</tr>
+		<!-- New thread capt -->
+		{% elseif config.new_thread_capt %}
+			<!-- :^) -->
+			{% if id %} 
+			{% else %}
+			<tr class='captcha'>
+                        <th>
+                                {% trans %}Verification{% endtrans %}
+                        </th>
+                        <td>
+                                <script>load_captcha("{{ config.captcha.provider_get }}", "{{ config.captcha.extra }}");</script>
+                        </td>
+                	</tr>
+			{% endif %}
 		{% endif %}
 
 		{% if config.user_flag %}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -89,11 +89,8 @@
 				<script>load_captcha("{{ config.captcha.provider_get }}", "{{ config.captcha.extra }}");</script>
 			</td>
 		</tr>
-		<!-- New thread capt -->
 		{% elseif config.new_thread_capt %}
-			<!-- :^) -->
-			{% if id %} 
-			{% else %}
+			{% if not id %} 
 			<tr class='captcha'>
                         <th>
                                 {% trans %}Verification{% endtrans %}


### PR DESCRIPTION
There needs to be a middle ground between no captcha and captcha for all post creation. This is a pull request for a board option to enable captcha for thread creation only. Users will NOT have to solve a captcha in order to reply. It's a nice compromise. Also included is a copy of README.md with a desperately needed update to the installation instructions. 