### PR TITLE
QR fix for tablet (portrait) mode in laptops

### DIFF
--- a/js/quick-reply.js
+++ b/js/quick-reply.js
@@ -115,7 +115,7 @@
 		#quick-reply td.recaptcha-response {\
 			padding: 0 0 1px 0;\
 		}\
-		@media screen and (max-width: 800px) {\
+		@media screen and (max-width: 600px) {\
 			#quick-reply {\
 				display: none !important;\
 			}\
@@ -369,7 +369,7 @@
 		$(window).ready(function() {
 			if (settings.get('hide_at_top', true)) {
 				$(window).scroll(function() {
-					if ($(this).width() <= 800)
+					if ($(this).width() <= 600)
 						return;
 					if ($(this).scrollTop() < $origPostForm.offset().top + $origPostForm.height() - 100)
 						$postForm.fadeOut(100);
@@ -391,7 +391,7 @@
 	};
 	
 	$(window).on('cite', function(e, id, with_link) {
-		if ($(this).width() <= 800)
+		if ($(this).width() <= 600)
 			return;
 		show_quick_reply();
 		if (with_link) {
@@ -446,7 +446,7 @@
 				$('.quick-reply-btn').hide();
 				
 				$(window).scroll(function() {
-					if ($(this).width() <= 800)
+					if ($(this).width() <= 600)
 						return;
 					if ($(this).scrollTop() < $('form[name="post"]:first').offset().top + $('form[name="post"]:first').height() - 100)
 						$('.quick-reply-btn').fadeOut(100);


### PR DESCRIPTION
Quick reply will now show up on tablets in portrait mode where width can be < 800px as originally coded (mainly 768x1280 and 800x1280)