### PR TITLE
fix missing semicolons in install.sql

### DIFF
--- a/install.sql
+++ b/install.sql
@@ -342,7 +342,7 @@ CREATE TABLE `tor_cookies` (
   `created` datetime NOT NULL,
   `uses` tinyint(3) unsigned DEFAULT '0',
   PRIMARY KEY (`cookie`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------
 
@@ -354,7 +354,7 @@ CREATE TABLE `dnsbl_bypass` (
   `ip` varchar(255) NOT NULL,
   `created` datetime DEFAULT NULL,
   PRIMARY KEY (`ip`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;


### PR DESCRIPTION
install.sql doesn't work after 26fe49f39b6a5560c1978e1d09e0d83dcf386a5c