### PR TITLE
lower hovered webm

### DIFF
--- a/js/expand-video.js
+++ b/js/expand-video.js
@@ -136,7 +136,7 @@ function setupVideo(thumb, url) {
 
             video.style.position = "fixed";
             video.style.right = "0px";
-            video.style.top = "0px";
+            video.style.top = "40px";
             var docRight = document.documentElement.getBoundingClientRect().right;
             var thumbRight = thumb.querySelector("img, video").getBoundingClientRect().right;
             video.style.maxWidth = maxWidth + "px";


### PR DESCRIPTION

![webmhover](https://cloud.githubusercontent.com/assets/10761304/6313269/729b2cc8-b967-11e4-90e4-44f80e6f6f82.jpg)

temp fix to lower the webm from the top of the window if hover is enabled, since the top of the video gets eaten by the board list/toolbar. may need to be even larger value if people use a ton of favorites

on the screenshot  you can see the thumb has some content on the top, and the hovered video is missing this (and viewing the video on separate tab shows the content)