### PR TITLE
Animate post form options toggle

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -24,7 +24,7 @@ body {
   width: 75px;
 }
 
-.post-table-options {
+.post-options-container {
   display: none;
 }
 

--- a/templates/main.js
+++ b/templates/main.js
@@ -457,16 +457,16 @@ function init() {
 	});
 
 	// just enable jquery, almost every script requires it by now. more and more main.js functions are going to start requiring it
-	$('.post-table-options').css('display', 'none');
+	$('.post-options-container').css('display', 'none');
 	window.optionsShowing = false;
 	$(document).on('click', '.show-post-table-options', function(e) {
 		if (!window.optionsShowing) { 
 			$('.show-post-table-options').html('[&#9660; '+_('Hide post options &amp; limits')+']'); 
-			$('.post-table-options').css('display', 'table');
+			$('.post-options-container').slideDown();
 			window.optionsShowing = true;
 		} else { 
 			$('.show-post-table-options').html('[&#9654; '+_('Show post options &amp; limits')+']'); 
-			$('.post-table-options').css('display', 'none');
+			$('.post-options-container').slideUp();
 			window.optionsShowing = false;
 		}; 
 	

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -154,17 +154,23 @@
 			<td>
 				<div class="no-bump-option">
 					<label><input title="No bump" id="no-bump" name="no-bump" type="checkbox">
-					{% trans %}Do not bump{% endtrans %} <span class="unimportant hint">{% trans %}(you can also write sage in the email field){% endtrans %}</span></label>
+					{% trans %}Do not bump{% endtrans %}
+					<br/>
+					<span class="unimportant hint">{% trans %}(you can also write sage in the email field){% endtrans %}</span></label>
 				</div>
 
 				{% if config.spoiler_images %}<div class="spoiler-images-option">
 					<label><input title="Spoiler images" id="spoiler" name="spoiler" type="checkbox">
-					{% trans %}Spoiler images{% endtrans %} <span class="unimportant hint">{% trans %}(this replaces the thumbnails of your images with question marks){% endtrans %}</label>
+					{% trans %}Spoiler images{% endtrans %}
+					<br/>
+					<span class="unimportant hint">{% trans %}(this replaces the thumbnails of your images with question marks){% endtrans %}</label>
 				</div>{% endif %}
 
 				{% if config.allow_no_country and config.country_flags %}<div class="no-country-option">
 					<label><input title="No country flag" id="no_country" name="no_country" type="checkbox">
-					{% trans %}Hide country{% endtrans %} <span class="unimportant hint">{% trans %}(this board displays your country when you post if this is unchecked){% endtrans %}</span></label>
+					{% trans %}Hide country{% endtrans %}
+					<br/>
+					<span class="unimportant hint">{% trans %}(this board displays your country when you post if this is unchecked){% endtrans %}</span></label>
 				</div>{% endif %}
 
 				{% if mod %}

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -112,7 +112,7 @@
 			</td>
 		</tr>
 	</tbody></table>
-	<table class="post-table-options"><tbody>
+	<div class="post-options-container"><table class="post-table-options"><tbody>
 
 		{% if config.user_flag %}
 			<tr>
@@ -223,7 +223,7 @@
 				</p>
 			</td>
 		</tr>
-	</tbody></table>
+	</tbody></table></div>
 </form>
 </div>
 </div>

--- a/templates/post_form.html
+++ b/templates/post_form.html
@@ -7,7 +7,7 @@
 	<input type="hidden" name="page" value="{{ current_page }}">
 {% endif %}
 {% if mod %}<input type="hidden" name="mod" value="1">{% endif %}
-	<table class="post-table">
+	<table class="post-table"><tbody>
 		{% if not config.field_disable_name or (mod and post.mod|hasPermission(config.mod.bypass_field_disable, board.uri)) %}<tr>
 			<th>
 				{% trans %}Name{% endtrans %}
@@ -111,7 +111,8 @@
 				<strong class="faq-message unimportant hint"><br />Confused? See the <a href="/faq.html">FAQ</a>.</strong>
 			</td>
 		</tr>
-		</tbody></table><table class="post-table-options"><tbody>
+	</tbody></table>
+	<table class="post-table-options"><tbody>
 
 		{% if config.user_flag %}
 			<tr>
@@ -222,7 +223,7 @@
 				</p>
 			</td>
 		</tr>
-	</table>
+	</tbody></table>
 </form>
 </div>
 </div>


### PR DESCRIPTION
Uses jQuery's slideUp and slideDown effect for toggling the options table

Added linebreaks before option hints to minimize post form width change on toggle.