### PR TITLE
Replace capital X by clearly superior ASCII ×

### DIFF
--- a/js/quick-reply.js
+++ b/js/quick-reply.js
@@ -182,7 +182,7 @@
 
 		$postForm.find('table:first').prepend('<tr><th colspan="2">\
 			<span class="handle">\
-				<a class="close-btn" href="javascript:void(0)">X</a>\
+				<a class="close-btn" href="javascript:void(0)">×</a>\
 				' + _('Quick Reply') + '\
 			</span>\
 			</th></tr>');


### PR DESCRIPTION
There's no reason to use a malformed letter when an ASCII character of a proper cross is available. This is an important issue, and I care about it very much.