### PR TITLE
Fix tab freeze when inlining

### DIFF
--- a/js/inline.js
+++ b/js/inline.js
@@ -139,7 +139,7 @@ $(document).ready(function() {
 
   if (App.options.get('useInlining')) {
     var assign_inline = function() {
-        $('.body a[href*="'+location.pathname+'"]:not([rel]):not(.toolong a), .mentioned a')
+        $('.body a[href*="'+location.pathname+'"]').not('[rel]').not('.toolong > a').add('.mentioned a')
           .attr('onclick', null)// XXX disable highlightReply
           .off('click')
           .click(inline)


### PR DESCRIPTION
Fixes ctrlcctrlv/infinity#451

Example, I get 381ms with the original query, but just 2ms with this. jQuery's .is() function says the original and faster queries are equivalent. I'm not sure why splitting up the query into multiple function calls like this works, but it does.