### PR TITLE
Prevent poster IDs from wordwrapping

### DIFF
--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -1018,6 +1018,7 @@ pre {
 
 .poster_id {
   cursor: pointer;
+  white-space:nowrap;
 }
 
 .poster_id::before {


### PR DESCRIPTION
![example of undesired word wrap](https://cloud.githubusercontent.com/assets/159372/10673485/fc77316e-78aa-11e5-94f0-15b4820355fb.png)
Poster IDs still linebreak between "ID:" and the ID, this corrects that without having to replace the space inbetween with an &amp;nbsp; nonbreaking space.